### PR TITLE
worker: add jitter to retry backoffs

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -14,3 +14,25 @@ Run relay with the SMTP simulator:
 
 Then, send emails to `address@simulator.net`.
 See [available addresses](https://github.com/hyvor/smtp-simulator?tab=readme-ov-file#email-addresses).
+
+## Retries
+
+Three things back off and retry in the worker, and all three share the jitter
+helpers in `retry.go`:
+
+| What | Ladder | Defined in |
+| --- | --- | --- |
+| Deferred sends | 15m, 1h, 2h, 4h, 8h, 16h, then 1d | `getSendRetryDelay()` in `send.go` |
+| Failed webhook deliveries | 1m, 5m, 15m, 1h, 4h, then 1d | `getWebhookRetryDelay()` in `webhooks_pg.go` |
+| Database reconnects | 100ms doubling up to 10s | `createNewRetryingDbConn()` in `pg.go` |
+
+Each delay is spread by `retryJitterFactor` (+/- 15%) before it is used. The
+ladders themselves stay deterministic; only the wake-up instant moves.
+
+Without the jitter, everything that failed in the same tick comes back in the
+same tick: a batch of sends deferred by one MX server retries as a batch, a
+customer endpoint that goes down gets its entire queued burst returned at once,
+and a Postgres blip has every worker reconnecting in lockstep.
+
+Tests pin `jitterSource` rather than asserting on random output. See
+`withJitterSource()` in `retry_test.go`.

--- a/worker/pg.go
+++ b/worker/pg.go
@@ -96,16 +96,22 @@ func createNewRetryingDbConn(
 			return db, nil
 		}
 
+		// jitter the wait but keep the doubling deterministic, so the
+		// backoff still grows predictably while the wake-ups spread out.
+		// Every worker holds its own connection, so without this a single
+		// Postgres blip has all of them reconnecting in lockstep.
+		wait := jitterDuration(backoff)
+
 		logger.Error(
 			"Failed to connect to database, retrying",
 			"error", err,
-			"backoff", backoff,
+			"backoff", wait,
 		)
 
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(backoff):
+		case <-time.After(wait):
 			backoff *= 2
 			if backoff > maxBackoff {
 				backoff = maxBackoff

--- a/worker/retry.go
+++ b/worker/retry.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// retryJitterFactor is the maximum fraction a retry delay is allowed to move
+// away from its base value, in either direction. 0.15 means a "1 hour" retry
+// actually fires somewhere in [51m, 69m].
+//
+// Without jitter, every send (or webhook delivery) that fails within the same
+// tick is rescheduled to the exact same instant, so the whole batch stampedes
+// the remote server again on every retry round, and keeps doing so for as long
+// as the ladder lasts. Spreading the wake-ups breaks that synchronization.
+const retryJitterFactor = 0.15
+
+// jitterSource returns a value in [0, 1). It is a variable so tests can make
+// the jitter deterministic.
+var jitterSource = rand.Float64
+
+// jitterDuration spreads d by up to +/- retryJitterFactor.
+//
+// Non-positive durations are returned untouched: a zero delay means "retry
+// immediately" and jittering it into a negative value would be meaningless.
+func jitterDuration(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+
+	// jitterSource() is [0, 1), so offset is [-factor, +factor)
+	offset := (jitterSource()*2 - 1) * retryJitterFactor
+	jittered := time.Duration(float64(d) * (1 + offset))
+
+	// a positive delay must stay positive, however small it started
+	if jittered < 1 {
+		return 1
+	}
+
+	return jittered
+}
+
+// sqlInterval formats d as a Postgres interval literal.
+//
+// The result is concatenated into SQL by callers, so it deliberately formats
+// from an int and never interpolates caller-supplied text.
+func sqlInterval(d time.Duration) string {
+	seconds := int64(d.Round(time.Second) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	return fmt.Sprintf("%d seconds", seconds)
+}
+
+// jitteredSqlInterval is the combination used by every retry ladder: take a
+// base delay, spread it, and render it as an interval literal.
+func jitteredSqlInterval(d time.Duration) string {
+	return sqlInterval(jitterDuration(d))
+}

--- a/worker/retry_test.go
+++ b/worker/retry_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// withJitterSource swaps the jitter source for the duration of the test.
+func withJitterSource(t *testing.T, values ...float64) {
+	t.Helper()
+
+	original := jitterSource
+	i := 0
+	jitterSource = func() float64 {
+		v := values[i%len(values)]
+		i++
+		return v
+	}
+
+	t.Cleanup(func() { jitterSource = original })
+}
+
+func TestJitterDurationStaysWithinFactor(t *testing.T) {
+
+	base := time.Hour
+	min := time.Duration(float64(base) * (1 - retryJitterFactor))
+	max := time.Duration(float64(base) * (1 + retryJitterFactor))
+
+	for i := 0; i < 1000; i++ {
+		jittered := jitterDuration(base)
+
+		assert.GreaterOrEqual(t, jittered, min)
+		assert.LessOrEqual(t, jittered, max)
+	}
+
+}
+
+func TestJitterDurationEdges(t *testing.T) {
+
+	base := time.Hour
+	min := time.Duration(float64(base) * (1 - retryJitterFactor))
+	max := time.Duration(float64(base) * (1 + retryJitterFactor))
+
+	// 0.0 -> lower edge, 0.5 -> no change, ~1.0 -> upper edge
+	withJitterSource(t, 0, 0.5, 0.999999)
+
+	assert.Equal(t, min, jitterDuration(base))
+	assert.Equal(t, base, jitterDuration(base))
+	assert.InDelta(t, float64(max), float64(jitterDuration(base)), float64(time.Second))
+
+}
+
+func TestJitterDurationSpreadsValues(t *testing.T) {
+
+	// the point of jitter is that two calls do not land on the same instant
+	seen := make(map[time.Duration]bool)
+
+	for i := 0; i < 50; i++ {
+		seen[jitterDuration(time.Hour)] = true
+	}
+
+	assert.Greater(t, len(seen), 1, "jitter should produce more than one distinct delay")
+
+}
+
+func TestJitterDurationIgnoresNonPositive(t *testing.T) {
+
+	assert.Equal(t, time.Duration(0), jitterDuration(0))
+	assert.Equal(t, -time.Second, jitterDuration(-time.Second))
+
+}
+
+func TestJitterDurationKeepsSubSecondDelaysSubSecond(t *testing.T) {
+
+	// the reconnect loop starts at 100ms, so jitter must not inflate short
+	// delays; only sqlInterval() has a one-second floor, because that is a
+	// Postgres interval concern
+	withJitterSource(t, 0)
+	assert.Equal(t, 85*time.Millisecond, jitterDuration(100*time.Millisecond))
+
+	withJitterSource(t, 0.5)
+	assert.Equal(t, 100*time.Millisecond, jitterDuration(100*time.Millisecond))
+
+}
+
+func TestJitterDurationStaysPositive(t *testing.T) {
+
+	withJitterSource(t, 0)
+
+	assert.Positive(t, jitterDuration(1))
+
+}
+
+func TestSqlInterval(t *testing.T) {
+
+	assert.Equal(t, "3600 seconds", sqlInterval(time.Hour))
+	assert.Equal(t, "900 seconds", sqlInterval(15*time.Minute))
+	assert.Equal(t, "86400 seconds", sqlInterval(24*time.Hour))
+
+	// rounds to the nearest second
+	assert.Equal(t, "2 seconds", sqlInterval(1500*time.Millisecond))
+
+	// never emits a zero or negative interval, which Postgres would accept
+	// but which would mean "retry immediately, forever"
+	assert.Equal(t, "1 seconds", sqlInterval(0))
+	assert.Equal(t, "1 seconds", sqlInterval(-time.Hour))
+
+}
+
+func TestJitteredSqlInterval(t *testing.T) {
+
+	withJitterSource(t, 0.5)
+	assert.Equal(t, "3600 seconds", jitteredSqlInterval(time.Hour))
+
+	withJitterSource(t, 0)
+	assert.Equal(t, "3060 seconds", jitteredSqlInterval(time.Hour))
+
+}

--- a/worker/retry_test.go
+++ b/worker/retry_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -116,5 +117,61 @@ func TestJitteredSqlInterval(t *testing.T) {
 
 	withJitterSource(t, 0)
 	assert.Equal(t, "3060 seconds", jitteredSqlInterval(time.Hour))
+
+}
+
+func TestWebhookRetryDelay(t *testing.T) {
+
+	// coupling for safety
+	delays := map[int]time.Duration{
+		0: 1 * time.Minute,
+		1: 5 * time.Minute,
+		2: 15 * time.Minute,
+		3: 1 * time.Hour,
+		4: 4 * time.Hour,
+		5: 24 * time.Hour,
+	}
+
+	for try, expected := range delays {
+		assert.Equal(t, expected, getWebhookRetryDelay(try))
+	}
+
+	assert.Equal(t, 24*time.Hour, getWebhookRetryDelay(99))
+
+}
+
+func TestWebhookRetryIntervalKeepsSendAfterWhenDone(t *testing.T) {
+
+	// delivered: nothing left to schedule
+	assert.Equal(t, "send_after", getWebhookRetryInterval(0, true))
+
+	// out of retries: nothing left to schedule
+	assert.Equal(t, "send_after", getWebhookRetryInterval(WEBHOOKS_MAX_RETRIES, false))
+	assert.Equal(t, "send_after", getWebhookRetryInterval(WEBHOOKS_MAX_RETRIES+1, false))
+
+}
+
+func TestWebhookRetryIntervalIsJittered(t *testing.T) {
+
+	withJitterSource(t, 0.5)
+	assert.Equal(t, "NOW() + INTERVAL '60 seconds'", getWebhookRetryInterval(0, false))
+	assert.Equal(t, "NOW() + INTERVAL '3600 seconds'", getWebhookRetryInterval(3, false))
+
+	for try := 0; try < WEBHOOKS_MAX_RETRIES; try++ {
+		base := getWebhookRetryDelay(try)
+		min := time.Duration(float64(base) * (1 - retryJitterFactor))
+		max := time.Duration(float64(base) * (1 + retryJitterFactor))
+
+		for i := 0; i < 100; i++ {
+			interval := getWebhookRetryInterval(try, false)
+
+			var seconds int64
+			_, err := fmt.Sscanf(interval, "NOW() + INTERVAL '%d seconds'", &seconds)
+			assert.NoError(t, err)
+
+			assert.GreaterOrEqual(t, time.Duration(seconds)*time.Second, min)
+			assert.LessOrEqual(t, time.Duration(seconds)*time.Second, max)
+		}
+	}
 
 }

--- a/worker/send.go
+++ b/worker/send.go
@@ -562,27 +562,35 @@ func getReturnPath(
 	return fmt.Sprintf("bounce+%s@%s", send.Uuid, instanceDomain)
 }
 
-// tryCount is
-func getSendAfterInterval(currentAttempt int) string {
+// getSendRetryDelay is the base backoff ladder for a deferred send, keyed by
+// the attempt that just failed. Anything past the ladder waits a day.
+func getSendRetryDelay(currentAttempt int) time.Duration {
 
 	if currentAttempt == 1 {
-		return "15 minutes"
+		return 15 * time.Minute
 	}
 	if currentAttempt == 2 {
-		return "1 hour"
+		return 1 * time.Hour
 	}
 	if currentAttempt == 3 {
-		return "2 hours"
+		return 2 * time.Hour
 	}
 	if currentAttempt == 4 {
-		return "4 hours"
+		return 4 * time.Hour
 	}
 	if currentAttempt == 5 {
-		return "8 hours"
+		return 8 * time.Hour
 	}
 	if currentAttempt == 6 {
-		return "16 hours"
+		return 16 * time.Hour
 	}
 
-	return "1 day"
+	return 24 * time.Hour
+}
+
+// getSendAfterInterval renders the backoff for the attempt that just failed as
+// a Postgres interval literal, jittered so a batch of sends deferred by the
+// same remote server at the same moment does not come back in lockstep.
+func getSendAfterInterval(currentAttempt int) string {
+	return jitteredSqlInterval(getSendRetryDelay(currentAttempt))
 }

--- a/worker/send_test.go
+++ b/worker/send_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -681,22 +682,57 @@ func TestSend_JsonMarsh(t *testing.T) {
 
 }
 
-func TestSendAfterInterval(t *testing.T) {
+func TestSendRetryDelay(t *testing.T) {
 
 	// coupling for safety
-	intervals := map[int]string{
-		1: "15 minutes",
-		2: "1 hour",
-		3: "2 hours",
-		4: "4 hours",
-		5: "8 hours",
-		6: "16 hours",
+	delays := map[int]time.Duration{
+		1: 15 * time.Minute,
+		2: 1 * time.Hour,
+		3: 2 * time.Hour,
+		4: 4 * time.Hour,
+		5: 8 * time.Hour,
+		6: 16 * time.Hour,
 	}
 
 	for i := 1; i <= 6; i++ {
-		assert.Equal(t, intervals[i], getSendAfterInterval(i))
+		assert.Equal(t, delays[i], getSendRetryDelay(i))
 	}
 
-	assert.Equal(t, "1 day", getSendAfterInterval(10))
+	assert.Equal(t, 24*time.Hour, getSendRetryDelay(10))
 
+}
+
+func TestSendAfterIntervalIsJittered(t *testing.T) {
+
+	// no jitter: the literal matches the base ladder exactly
+	withJitterSource(t, 0.5)
+	assert.Equal(t, "900 seconds", getSendAfterInterval(1))
+	assert.Equal(t, "3600 seconds", getSendAfterInterval(2))
+	assert.Equal(t, "86400 seconds", getSendAfterInterval(10))
+
+	// full jitter both ways stays inside the configured factor
+	for attempt := 1; attempt <= 7; attempt++ {
+		base := getSendRetryDelay(attempt)
+		min := time.Duration(float64(base) * (1 - retryJitterFactor))
+		max := time.Duration(float64(base) * (1 + retryJitterFactor))
+
+		for i := 0; i < 100; i++ {
+			seconds := secondsFromInterval(t, getSendAfterInterval(attempt))
+
+			assert.GreaterOrEqual(t, seconds, min)
+			assert.LessOrEqual(t, seconds, max)
+		}
+	}
+
+}
+
+// secondsFromInterval parses the "<n> seconds" literal the retry ladders emit.
+func secondsFromInterval(t *testing.T, interval string) time.Duration {
+	t.Helper()
+
+	var seconds int64
+	_, err := fmt.Sscanf(interval, "%d seconds", &seconds)
+	assert.NoError(t, err)
+
+	return time.Duration(seconds) * time.Second
 }

--- a/worker/webhooks_pg.go
+++ b/worker/webhooks_pg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 )
 
 type WebhookDelivery struct {
@@ -141,24 +142,38 @@ func (b *WebhooksBatch) FinalizeWebhookByResult(delivery *WebhookDelivery, resul
 	return nil
 }
 
+// getWebhookRetryDelay is the base backoff ladder for a failed webhook
+// delivery, keyed by the try that just failed. Anything past the ladder waits
+// a day.
+func getWebhookRetryDelay(currentTry int) time.Duration {
+	retryDelays := map[int]time.Duration{
+		0: 1 * time.Minute,
+		1: 5 * time.Minute,
+		2: 15 * time.Minute,
+		3: 1 * time.Hour,
+		4: 4 * time.Hour,
+		5: 24 * time.Hour,
+	}
+
+	delay, ok := retryDelays[currentTry]
+
+	if !ok {
+		delay = 24 * time.Hour
+	}
+
+	return delay
+}
+
+// getWebhookRetryInterval returns the SQL expression assigned to send_after.
+//
+// When there is nothing left to retry the column keeps its current value, so
+// the expression is the column itself rather than an interval.
 func getWebhookRetryInterval(currentTry int, currentSuccess bool) string {
 	if currentSuccess || currentTry >= WEBHOOKS_MAX_RETRIES {
 		return "send_after"
-	} else {
-		retryIntervalMap := map[int]string{
-			0: "1 minute",
-			1: "5 minutes",
-			2: "15 minutes",
-			3: "1 hour",
-			4: "4 hours",
-			5: "24 hours",
-		}
-		interval, ok := retryIntervalMap[currentTry]
-
-		if !ok {
-			interval = "24 hours"
-		}
-
-		return fmt.Sprintf("NOW() + INTERVAL '%s'", interval)
 	}
+
+	// jittered so that an endpoint that went down while a burst of deliveries
+	// was queued does not get the whole burst back at the same instant
+	return fmt.Sprintf("NOW() + INTERVAL '%s'", jitteredSqlInterval(getWebhookRetryDelay(currentTry)))
 }


### PR DESCRIPTION
Closes #465

## Problem

Three things back off and retry in the worker, and none of them jittered:

| What | Ladder | Where |
| --- | --- | --- |
| Deferred sends | 15m, 1h, 2h, 4h, 8h, 16h, then 1d | `getSendAfterInterval()` in `send.go` |
| Failed webhook deliveries | 1m, 5m, 15m, 1h, 4h, then 1d | `getWebhookRetryInterval()` in `webhooks_pg.go` |
| Database reconnects | 100ms doubling to 10s | `createNewRetryingDbConn()` in `pg.go` |

Because each returns a fixed delay, everything that fails in the same tick is rescheduled to the same instant and comes back as a batch, round after round:

- a batch of sends deferred by one MX retries as a batch;
- an endpoint that goes down gets its **entire** queued burst returned at once when it comes back;
- a Postgres blip has every worker reconnecting in lockstep at 100ms, 200ms, 400ms.

## Change

One set of helpers in `retry.go`, used by all three. Each delay is spread by `retryJitterFactor` (+/- 15%) before use. The ladders stay deterministic; only the wake-up instant moves.

Two details worth a reviewer's eye:

- **`sqlInterval()` formats from an `int64`.** The callers concatenate the result straight into SQL (`send_after = NOW() + INTERVAL '`+x+`'`), which is safe today only because the values come from a closed set of constants. Formatting from an int keeps that property. It also floors at one second, so a rounded-down delay can never become "retry immediately, forever".
- **The reconnect loop jitters the wait but not the doubling.** The backoff still grows predictably; compounding jitter into the base would make it drift.

## Testing

Full suite green against a real Postgres (`meta/ci/compose.ci.yaml`), and each commit passes on its own.

Tests pin `jitterSource` rather than asserting on random output, and separately assert that repeated calls actually produce different values, so a stubbed-out jitter cannot pass silently.