### PR TITLE
worker: count workers as they start and stop

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -14,3 +14,19 @@ Run relay with the SMTP simulator:
 
 Then, send emails to `address@simulator.net`.
 See [available addresses](https://github.com/hyvor/smtp-simulator?tab=readme-ov-file#email-addresses).
+
+## Worker metrics
+
+`workers_email_total`, `workers_webhook_total` and `workers_incoming_mail_total`
+are owned by the worker goroutines themselves: each one `Inc()`s as it starts
+and `Dec()`s through a `defer` as it exits. `MetricsServer.Set()` must never
+write to them.
+
+That means the gauges report workers that are actually running, so they drop
+when a worker dies (for example when it cannot reach the database) and briefly
+show two generations while a state update is draining the old one. Reporting
+the configured count instead would hide both.
+
+`workers_api_total` is the exception and is still set from `GoState`. The API
+workers are PHP processes owned by the backend, which this binary cannot
+observe.

--- a/worker/email_worker.go
+++ b/worker/email_worker.go
@@ -148,6 +148,12 @@ func (worker *EmailWorker) Start() {
 
 	defer worker.wg.Done()
 
+	// count the goroutine, not the configured worker count, so the gauge
+	// reflects workers that actually got running and drops again as soon as
+	// one exits (including the early return below)
+	worker.metrics.workersEmailTotal.Inc()
+	defer worker.metrics.workersEmailTotal.Dec()
+
 	conn, err := NewRetryingDbConn(
 		worker.ctx,
 		worker.dbConfig,

--- a/worker/email_worker_test.go
+++ b/worker/email_worker_test.go
@@ -56,6 +56,7 @@ func TestEmailWorkersPoolSet(t *testing.T) {
 		ctx:        ctx,
 		cancelFunc: cancel,
 		logger:     slogDiscard(),
+		metrics:    newMetrics(),
 	}
 
 	pool.Set([]GoStateIp{
@@ -159,7 +160,8 @@ func TestEmailWorker_CallsProcessSend(t *testing.T) {
 			cancel()
 			return nil
 		},
-		logger: slogDiscard(),
+		logger:  slogDiscard(),
+		metrics: newMetrics(),
 	}
 
 	go emailWorker.Start()
@@ -540,5 +542,67 @@ func TestEmailWorker_AttemptSendToDomain(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "accepted", updatedRecipient.Status)
 	assert.Equal(t, 1, updatedRecipient.TryCount)
+
+}
+
+func TestEmailWorkerGaugeTracksGoroutineLifetime(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// keep the workers parked in the reconnect loop so they stay alive until
+	// the context is cancelled
+	originalNewDbConn := NewDbConn
+	NewDbConn = func(config *DBConfig) (*sql.DB, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { NewDbConn = originalNewDbConn }()
+
+	metrics := newMetrics()
+	var wg sync.WaitGroup
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ip := GoStateIp{Ip: "1.1.1.1", QueueId: 1, QueueName: "test"}
+
+	assert.Equal(t, 0.0, gaugeValue(t, metrics.workersEmailTotal))
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go NewEmailWorker(ctx, i, &wg, &DBConfig{}, logger, metrics, ip, "relay.hyvor.com").Start()
+	}
+
+	assert.Eventually(t, func() bool {
+		return gaugeValue(t, metrics.workersEmailTotal) == 2.0
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, 0.0, gaugeValue(t, metrics.workersEmailTotal))
+
+}
+
+func TestEmailWorkerGaugeDropsWhenWorkerNeverStarts(t *testing.T) {
+
+	// a worker whose context is already dead exits before it does any work.
+	// The old code still reported it as a running worker; the gauge must end
+	// at zero.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	originalNewDbConn := NewDbConn
+	NewDbConn = func(config *DBConfig) (*sql.DB, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { NewDbConn = originalNewDbConn }()
+
+	metrics := newMetrics()
+	var wg sync.WaitGroup
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ip := GoStateIp{Ip: "1.1.1.1", QueueId: 1, QueueName: "test"}
+
+	wg.Add(1)
+	go NewEmailWorker(ctx, 1, &wg, &DBConfig{}, logger, metrics, ip, "relay.hyvor.com").Start()
+	wg.Wait()
+
+	assert.Equal(t, 0.0, gaugeValue(t, metrics.workersEmailTotal))
 
 }

--- a/worker/incoming_handler.go
+++ b/worker/incoming_handler.go
@@ -144,6 +144,13 @@ func incomingMailWorker(
 	mailChannel chan *IncomingMail,
 ) {
 
+	// see EmailWorker.Start(): the gauge tracks live goroutines, not the
+	// configured worker count. This pool is not wait-grouped, so a state
+	// update can briefly overlap two generations of workers; the gauge
+	// showing that overlap is the point.
+	metrics.workersIncomingTotal.Inc()
+	defer metrics.workersIncomingTotal.Dec()
+
 	logger.Debug("Starting incoming mail handler", "worker", i)
 
 	for {

--- a/worker/incoming_handler_test.go
+++ b/worker/incoming_handler_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -178,5 +181,31 @@ Return-Path: <return@hyvor.com>
 	assert.Equal(t, "sender@example.org", bodyMap["mail_from"])
 	assert.Equal(t, "fbl@relay.com", bodyMap["rcpt_to"])
 	assert.Equal(t, string(m.Data), bodyMap["raw_email"])
+
+}
+
+func TestIncomingMailWorkerGaugeTracksGoroutineLifetime(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	metrics := newMetrics()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mailChannel := make(chan *IncomingMail)
+
+	assert.Equal(t, 0.0, gaugeValue(t, metrics.workersIncomingTotal))
+
+	for i := 0; i < 3; i++ {
+		go incomingMailWorker(ctx, i, logger, metrics, mailChannel)
+	}
+
+	assert.Eventually(t, func() bool {
+		return gaugeValue(t, metrics.workersIncomingTotal) == 3.0
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+
+	assert.Eventually(t, func() bool {
+		return gaugeValue(t, metrics.workersIncomingTotal) == 0.0
+	}, time.Second, 5*time.Millisecond)
 
 }

--- a/worker/metrics.go
+++ b/worker/metrics.go
@@ -224,10 +224,12 @@ func (server *MetricsServer) Set(goState GoState) {
 		goState.Env,
 		goState.InstanceDomain,
 	).Set(1)
+	// workers_api_total is the only worker gauge still set from the state:
+	// the API workers are PHP processes owned by the backend, so this process
+	// can only report the configured number. The email, webhook and incoming
+	// gauges are owned by the goroutines themselves (Inc on start, Dec on
+	// exit) and must not be overwritten here.
 	server.metrics.workersApiTotal.Set(float64(goState.ApiWorkers))
-	server.metrics.workersEmailTotal.Set(float64(len(goState.Ips) * goState.EmailWorkersPerIp))
-	server.metrics.workersWebhookTotal.Set(float64(goState.WebhookWorkers))
-	server.metrics.workersIncomingTotal.Set(float64(goState.IncomingWorkers))
 	server.metrics.serversTotal.Set(float64(goState.ServersCount))
 
 	if !server.serverStarted {

--- a/worker/metrics_test.go
+++ b/worker/metrics_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -111,4 +113,47 @@ func TestIsIpApproved(t *testing.T) {
 			t.Errorf("isPrivateIp(%s) = %v; expected %v", tt.remoteAddr, got, tt.expected)
 		}
 	}
+}
+
+func TestWorkerGaugesAreNotOverwrittenByState(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	metricsServer := NewMetricsServer(ctx, slogDiscard())
+
+	// pretend three email workers, two webhook workers and one incoming
+	// worker actually started
+	metricsServer.metrics.workersEmailTotal.Add(3)
+	metricsServer.metrics.workersWebhookTotal.Add(2)
+	metricsServer.metrics.workersIncomingTotal.Add(1)
+
+	// a state update asking for far more workers must not move the gauges:
+	// the goroutines have not started yet, so reporting them would be a lie
+	metricsServer.Set(GoState{
+		IsLeader:          false,
+		Ips:               []GoStateIp{{Id: 1}, {Id: 2}},
+		EmailWorkersPerIp: 50,
+		WebhookWorkers:    50,
+		IncomingWorkers:   50,
+		ApiWorkers:        7,
+	})
+
+	assert.Equal(t, 3.0, gaugeValue(t, metricsServer.metrics.workersEmailTotal))
+	assert.Equal(t, 2.0, gaugeValue(t, metricsServer.metrics.workersWebhookTotal))
+	assert.Equal(t, 1.0, gaugeValue(t, metricsServer.metrics.workersIncomingTotal))
+
+	// API workers are PHP processes this binary does not own, so that gauge
+	// is still reported from the state
+	assert.Equal(t, 7.0, gaugeValue(t, metricsServer.metrics.workersApiTotal))
+
+}
+
+func gaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
+
+	metric := &dto.Metric{}
+	assert.NoError(t, gauge.Write(metric))
+
+	return metric.GetGauge().GetValue()
 }

--- a/worker/webhooks.go
+++ b/worker/webhooks.go
@@ -102,6 +102,11 @@ func webhookWorker(
 ) {
 	defer wg.Done()
 
+	// see EmailWorker.Start(): the gauge tracks live goroutines, not the
+	// configured worker count
+	metrics.workersWebhookTotal.Inc()
+	defer metrics.workersWebhookTotal.Dec()
+
 	logger.Debug("Webhook worker started", "id", id)
 
 	conn, err := NewRetryingDbConn(ctx, dbConfig, logger)

--- a/worker/webhooks_test.go
+++ b/worker/webhooks_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -53,6 +55,7 @@ func TestWebhookWorkersPoolSet(t *testing.T) {
 		cancelFunc: cancelFunc,
 		workerFunc: mockWorker,
 		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		metrics:    newMetrics(),
 	}
 
 	pool.Set(2)
@@ -292,4 +295,37 @@ func (suite *WebhookWorkerTestSuite) TestWebhookDeliveryWithSignatureHeader() {
 	suite.Equal(200, int(delivery.ResponseCode.Int64))
 	suite.Equal(1, delivery.TryCount)
 	suite.Equal(testSignature, delivery.Signature.String)
+}
+
+func TestWebhookWorkerGaugeTracksGoroutineLifetime(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// keep the worker parked in the reconnect loop so it stays alive until
+	// the context is cancelled
+	originalNewDbConn := NewDbConn
+	NewDbConn = func(config *DBConfig) (*sql.DB, error) {
+		return nil, errors.New("connection failed")
+	}
+	defer func() { NewDbConn = originalNewDbConn }()
+
+	metrics := newMetrics()
+	var wg sync.WaitGroup
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	assert.Equal(t, 0.0, gaugeValue(t, metrics.workersWebhookTotal))
+
+	wg.Add(2)
+	go webhookWorker(ctx, 1, &wg, &DBConfig{}, logger, metrics)
+	go webhookWorker(ctx, 2, &wg, &DBConfig{}, logger, metrics)
+
+	assert.Eventually(t, func() bool {
+		return gaugeValue(t, metrics.workersWebhookTotal) == 2.0
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, 0.0, gaugeValue(t, metrics.workersWebhookTotal))
+
 }


### PR DESCRIPTION
Closes #241

## Problem

`MetricsServer.Set()` wrote the *configured* worker counts straight into the gauges on every state update:

```go
server.metrics.workersEmailTotal.Set(float64(len(goState.Ips) * goState.EmailWorkersPerIp))
server.metrics.workersWebhookTotal.Set(float64(goState.WebhookWorkers))
server.metrics.workersIncomingTotal.Set(float64(goState.IncomingWorkers))
```

That reports intent, not reality:

- the gauge jumps to the new value while the previous generation of goroutines is still draining;
- a worker that dies early (for example one that never gets past `NewRetryingDbConn()`) is still counted;
- the incoming pool is worst, because `StartChannelAndSmtpServers()` has no WaitGroup and does not wait for the old generation at all.

## Change

As suggested in the issue, the gauges are now owned by the goroutines: `Inc()` on entry, `Dec()` on exit via `defer`, which covers context cancellation and early error returns. `MetricsServer.Set()` no longer touches them.

The gauges now briefly show two generations during a state update. That is the accurate reading: both sets of workers really are alive.

### One deliberate exception

`workers_api_total` is still set from `GoState`. The API workers are PHP processes owned by the backend (`ApiWorkers` is even annotated `// only for metrics`), so this binary cannot observe them and can only report the configured number. That is commented in place so a future change does not "finish the job" by mistake.

## Testing

Full suite green against a real Postgres, and each commit passes on its own.

New tests assert the gauge reaches the number of live goroutines, returns to zero on cancellation, and that a state update asking for 50 workers does **not** move a gauge that reflects 3 running ones.

Note: this surfaced that a few existing tests built partial `EmailWorkersPool` / `EmailWorker` / `WebhookWorkersPool` values with a nil `*Metrics`. Harmless before, since nothing on those paths touched the field, but `Start()` now dereferences it. Only the literals that actually reach `Start()` were given a real `Metrics`; the `StopWorkers` tests never construct a worker and were left alone.