### PR TITLE
worker: fall back to TLS 1.2 when the STARTTLS handshake is rejected

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -14,3 +14,27 @@ Run relay with the SMTP simulator:
 
 Then, send emails to `address@simulator.net`.
 See [available addresses](https://github.com/hyvor/smtp-simulator?tab=readme-ov-file#email-addresses).
+
+## Outgoing TLS
+
+Delivery uses opportunistic STARTTLS: if the receiving server advertises the
+extension, `sendEmailToHostWithTlsMaxVersion()` upgrades the connection before
+`MAIL FROM`.
+
+Some receiving servers abort the handshake when they see a TLS 1.3
+`ClientHello`, even though they would negotiate TLS 1.2 without complaint. When
+that happens the host is dialled a second time with `MaxVersion` pinned to
+`tlsFallbackMaxVersion`. A fresh connection is required, because STARTTLS has
+already been issued on the failed one.
+
+Two things are easy to get wrong here:
+
+- The handshake is **lazy**. `tls.Client()` returns immediately, so a rejected
+  `ClientHello` surfaces as an error from the EHLO that follows STARTTLS, not
+  from `StartTLS()` itself.
+- Not every TLS error is worth a retry. Certificate failures are excluded,
+  because a lower version cannot fix an untrusted certificate and retrying
+  would double the connections to every misconfigured host. See
+  `isTlsVersionNegotiationError()` for the error shapes involved; they are not
+  uniform, and the test suite drives real handshakes rather than constructing
+  error values.

--- a/worker/send.go
+++ b/worker/send.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -418,8 +417,35 @@ func sendEmailToHostHandler(
 	ip string,
 	ptr string,
 ) *SmtpConversation {
+
 	// 0 means "no ceiling", so crypto/tls picks its own maximum
-	return sendEmailToHostWithTlsMaxVersion(send, recipients, host, instanceDomain, ip, ptr, 0)
+	conversation := sendEmailToHostWithTlsMaxVersion(send, recipients, host, instanceDomain, ip, ptr, 0)
+
+	if !conversation.tlsHandshakeFailed {
+		return conversation
+	}
+
+	// Some receiving servers abort the handshake when they see a TLS 1.3
+	// ClientHello even though they negotiate TLS 1.2 happily. Retry the host
+	// once with the version capped before giving up on it.
+	//
+	// This needs a fresh connection: STARTTLS has already been issued on the
+	// old one and the handshake failed, so that socket cannot be reused.
+	retry := sendEmailToHostWithTlsMaxVersion(
+		send,
+		recipients,
+		host,
+		instanceDomain,
+		ip,
+		ptr,
+		tlsFallbackMaxVersion,
+	)
+
+	// keep the failed attempt in the conversation, otherwise the logs show a
+	// successful TLS 1.2 delivery with no sign that 1.3 was tried first
+	retry.Steps = append(conversation.Steps, retry.Steps...)
+
+	return retry
 }
 
 func sendEmailToHostWithTlsMaxVersion(
@@ -462,10 +488,7 @@ func sendEmailToHostWithTlsMaxVersion(
 	// ============
 	if ok, _ := c.Extension("STARTTLS"); ok {
 
-		startTlsResult, ehloResult := c.StartTLS(&tls.Config{
-			ServerName: host,
-			MaxVersion: tlsMaxVersion,
-		})
+		startTlsResult, ehloResult := c.StartTLS(newSendTlsConfig(host, tlsMaxVersion))
 
 		if startTlsResult.Err != nil {
 			conversation.NetworkError = startTlsResult.Err

--- a/worker/send.go
+++ b/worker/send.go
@@ -100,6 +100,11 @@ type SmtpConversation struct {
 	// results for each recipient, indexed by recipient ID
 	RcptResults []*RcptResult `json:"-"`
 
+	// set when NetworkError came from the STARTTLS handshake and looks like
+	// something a lower TLS version could get past. Unexported so it stays
+	// out of the stored conversation; it only drives the retry decision.
+	tlsHandshakeFailed bool `json:"-"`
+
 	// simply record all steps for debugging
 	Steps []*SmtpStep `json:"steps"`
 }
@@ -413,6 +418,19 @@ func sendEmailToHostHandler(
 	ip string,
 	ptr string,
 ) *SmtpConversation {
+	// 0 means "no ceiling", so crypto/tls picks its own maximum
+	return sendEmailToHostWithTlsMaxVersion(send, recipients, host, instanceDomain, ip, ptr, 0)
+}
+
+func sendEmailToHostWithTlsMaxVersion(
+	send *SendRow,
+	recipients []*RecipientRow,
+	host string,
+	instanceDomain string,
+	ip string,
+	ptr string,
+	tlsMaxVersion uint16,
+) *SmtpConversation {
 
 	conversation := NewSmtpConversation()
 
@@ -444,15 +462,23 @@ func sendEmailToHostHandler(
 	// ============
 	if ok, _ := c.Extension("STARTTLS"); ok {
 
-		startTlsResult, ehloResult := c.StartTLS(&tls.Config{ServerName: host})
+		startTlsResult, ehloResult := c.StartTLS(&tls.Config{
+			ServerName: host,
+			MaxVersion: tlsMaxVersion,
+		})
 
 		if startTlsResult.Err != nil {
 			conversation.NetworkError = startTlsResult.Err
 			return conversation
 		}
 
+		// tls.Client() handshakes lazily, so a handshake failure surfaces
+		// here, on the first read of the EHLO that follows, rather than from
+		// StartTLS itself.
 		if ehloResult.Err != nil {
+			conversation.AddStepFromResult(SmtpStepStartTLS, &startTlsResult)
 			conversation.NetworkError = ehloResult.Err
+			conversation.tlsHandshakeFailed = isTlsVersionNegotiationError(ehloResult.Err)
 			return conversation
 		}
 

--- a/worker/tls_fallback.go
+++ b/worker/tls_fallback.go
@@ -12,6 +12,18 @@ import (
 // ClientHello even though they would happily negotiate TLS 1.2.
 const tlsFallbackMaxVersion = tls.VersionTLS12
 
+// newSendTlsConfig builds the client config used for outgoing STARTTLS.
+//
+// maxVersion of 0 leaves the ceiling to crypto/tls. It is a variable for the
+// same reason createSmtpClient is: tests need to point it at throwaway
+// certificates without weakening the real path.
+var newSendTlsConfig = func(host string, maxVersion uint16) *tls.Config {
+	return &tls.Config{
+		ServerName: host,
+		MaxVersion: maxVersion,
+	}
+}
+
 // isTlsVersionNegotiationError reports whether err looks like a handshake
 // failure that capping the TLS version might get past.
 //

--- a/worker/tls_fallback.go
+++ b/worker/tls_fallback.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"strings"
+)
+
+// tlsFallbackMaxVersion is the ceiling used when retrying a host whose TLS
+// handshake failed. Some receiving servers, particularly older or
+// middlebox-fronted ones, abort the handshake when they see a TLS 1.3
+// ClientHello even though they would happily negotiate TLS 1.2.
+const tlsFallbackMaxVersion = tls.VersionTLS12
+
+// isTlsVersionNegotiationError reports whether err looks like a handshake
+// failure that capping the TLS version might get past.
+//
+// The error shapes here were confirmed against crypto/tls rather than
+// guessed, because they are not uniform:
+//
+//   - A peer that rejects our ClientHello answers with an alert, which
+//     crypto/tls surfaces as the unexported *tls.permanentError wrapping a
+//     string such as "remote error: tls: protocol version not supported".
+//     There is no exported type to match on, so this case has to be detected
+//     by message.
+//   - A peer that answers with something that is not a TLS record at all
+//     gives us a tls.RecordHeaderError.
+//   - A certificate problem gives us *tls.CertificateVerificationError. Its
+//     message also contains "tls: ", so it must be excluded before the
+//     message check, and it is excluded because lowering the version cannot
+//     fix an untrusted certificate.
+func isTlsVersionNegotiationError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return false
+	}
+
+	var recordErr tls.RecordHeaderError
+	if errors.As(err, &recordErr) {
+		return true
+	}
+
+	// covers both the remote alerts above and local failures such as
+	// "tls: server selected unsupported protocol version"
+	return strings.Contains(err.Error(), "tls: ")
+}

--- a/worker/tls_fallback_send_test.go
+++ b/worker/tls_fallback_send_test.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	smtp "github.com/hyvor/relay/worker/smtp"
+)
+
+// tlsIntolerantServer is an SMTP server that offers STARTTLS but aborts the
+// handshake when the client advertises TLS 1.3, which is how the servers in
+// issue #466 behave. Set intolerant to false for a server that accepts any
+// version.
+type tlsIntolerantServer struct {
+	listener    net.Listener
+	cert        tls.Certificate
+	intolerant  bool
+	connections atomic.Int32
+	tlsVersions chan uint16
+}
+
+func startTlsIntolerantSmtpServer(t *testing.T, intolerant bool) *tlsIntolerantServer {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	server := &tlsIntolerantServer{
+		listener:    listener,
+		cert:        selfSignedCert(t),
+		intolerant:  intolerant,
+		tlsVersions: make(chan uint16, 8),
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			server.connections.Add(1)
+			go server.handle(conn)
+		}
+	}()
+
+	return server
+}
+
+func (s *tlsIntolerantServer) handle(conn net.Conn) {
+	defer conn.Close()
+
+	write := func(format string, args ...any) error {
+		_, err := fmt.Fprintf(conn, format+"\r\n", args...)
+		return err
+	}
+
+	reader := bufio.NewReader(conn)
+
+	if write("220 test.local ESMTP") != nil {
+		return
+	}
+
+	// plaintext phase: EHLO then STARTTLS
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+
+		command := strings.ToUpper(strings.TrimSpace(line))
+
+		switch {
+		case strings.HasPrefix(command, "EHLO"), strings.HasPrefix(command, "HELO"):
+			if write("250-test.local Hello\r\n250 STARTTLS") != nil {
+				return
+			}
+		case command == "STARTTLS":
+			if write("220 Ready to start TLS") != nil {
+				return
+			}
+			s.serveTls(conn)
+			return
+		case command == "QUIT":
+			write("221 Bye")
+			return
+		default:
+			if write("502 Command not implemented") != nil {
+				return
+			}
+		}
+	}
+}
+
+func (s *tlsIntolerantServer) serveTls(conn net.Conn) {
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{s.cert},
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			// a real TLS 1.3-intolerant server aborts on the ClientHello
+			// rather than negotiating down, which is exactly what makes the
+			// failure unrecoverable on this connection
+			if s.intolerant {
+				for _, version := range hello.SupportedVersions {
+					if version >= tls.VersionTLS13 {
+						return nil, fmt.Errorf("tls 1.3 not supported")
+					}
+				}
+			}
+			return nil, nil
+		},
+	}
+
+	tlsConn := tls.Server(conn, config)
+
+	if err := tlsConn.Handshake(); err != nil {
+		return
+	}
+
+	s.tlsVersions <- tlsConn.ConnectionState().Version
+
+	// encrypted phase: accept the message
+	reader := bufio.NewReader(tlsConn)
+	write := func(format string, args ...any) error {
+		_, err := fmt.Fprintf(tlsConn, format+"\r\n", args...)
+		return err
+	}
+
+	inData := false
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		if inData {
+			if trimmed == "." {
+				inData = false
+				if write("250 Message accepted") != nil {
+					return
+				}
+			}
+			continue
+		}
+
+		command := strings.ToUpper(trimmed)
+
+		switch {
+		case strings.HasPrefix(command, "EHLO"), strings.HasPrefix(command, "HELO"):
+			err = write("250-test.local Hello\r\n250 SIZE 10240000")
+		case strings.HasPrefix(command, "MAIL FROM"):
+			err = write("250 Sender OK")
+		case strings.HasPrefix(command, "RCPT TO"):
+			err = write("250 Recipient OK")
+		case command == "DATA":
+			inData = true
+			err = write("354 Send data")
+		case command == "QUIT":
+			write("221 Bye")
+			return
+		default:
+			err = write("502 Command not implemented")
+		}
+
+		if err != nil {
+			return
+		}
+	}
+}
+
+// pointSmtpClientAt makes createSmtpClient dial the test server, ignoring the
+// host and local IP the worker would normally bind.
+func pointSmtpClientAt(t *testing.T, address string) {
+	t.Helper()
+
+	original := createSmtpClient
+	createSmtpClient = func(host string, _ string) (*smtp.Client, error) {
+		conn, err := net.Dial("tcp", address)
+		if err != nil {
+			return nil, err
+		}
+		return smtp.NewClient(conn, host)
+	}
+
+	t.Cleanup(func() { createSmtpClient = original })
+}
+
+func testSendAndRecipient() (*SendRow, []*RecipientRow) {
+	send := &SendRow{
+		Id:        1,
+		Uuid:      "test-uuid",
+		From:      "test@hyvor.com",
+		RawEmail:  "Subject: Test Email",
+		QueueName: "default",
+	}
+	return send, []*RecipientRow{{Id: 1, Type: "to", Address: "accept@test.local"}}
+}
+
+func TestSendEmailToHost_FallsBackToTls12(t *testing.T) {
+
+	server := startTlsIntolerantSmtpServer(t, true)
+	pointSmtpClientAt(t, server.listener.Addr().String())
+
+	// the cert is self-signed, so skip verification for the test; version
+	// negotiation is what is under test here
+	restoreVerify := skipTlsVerifyForTest(t)
+	defer restoreVerify()
+
+	send, recipients := testSendAndRecipient()
+
+	conversation := sendEmailToHost(send, recipients, "test.local", "relay.com", "127.0.0.1", "smtp.relay.com")
+
+	// the message got through on the second attempt
+	assert.NoError(t, conversation.NetworkError)
+
+	// without the fallback this is empty, so stop here rather than panicking
+	if !assert.Len(t, conversation.RcptResults, 1) {
+		t.FailNow()
+	}
+	assert.Equal(t, 250, conversation.RcptResults[0].Code)
+
+	// exactly two connections: the rejected TLS 1.3 attempt and the fallback
+	assert.Equal(t, int32(2), server.connections.Load())
+
+	negotiated := <-server.tlsVersions
+	assert.Equal(t, uint16(tls.VersionTLS12), negotiated)
+
+	// the failed attempt is still visible in the conversation
+	var starttlsSteps int
+	for _, step := range conversation.Steps {
+		if step.Name == SmtpStepStartTLS {
+			starttlsSteps++
+		}
+	}
+	assert.Equal(t, 2, starttlsSteps, "both STARTTLS attempts should be recorded")
+
+}
+
+func TestSendEmailToHost_NoFallbackWhenTlsSucceeds(t *testing.T) {
+
+	server := startTlsIntolerantSmtpServer(t, false)
+	pointSmtpClientAt(t, server.listener.Addr().String())
+
+	restoreVerify := skipTlsVerifyForTest(t)
+	defer restoreVerify()
+
+	send, recipients := testSendAndRecipient()
+
+	conversation := sendEmailToHost(send, recipients, "test.local", "relay.com", "127.0.0.1", "smtp.relay.com")
+
+	assert.NoError(t, conversation.NetworkError)
+
+	if !assert.Len(t, conversation.RcptResults, 1) {
+		t.FailNow()
+	}
+	assert.Equal(t, 250, conversation.RcptResults[0].Code)
+
+	// a healthy server must not pay for a second connection
+	assert.Equal(t, int32(1), server.connections.Load())
+
+	negotiated := <-server.tlsVersions
+	assert.Equal(t, uint16(tls.VersionTLS13), negotiated)
+
+}

--- a/worker/tls_fallback_test.go
+++ b/worker/tls_fallback_test.go
@@ -182,3 +182,19 @@ func TestTlsFallbackReachesAVersionIntolerantPeer(t *testing.T) {
 	assert.False(t, isTlsVersionNegotiationError(err), "got %v", err)
 
 }
+
+// skipTlsVerifyForTest relaxes certificate verification for the outgoing
+// STARTTLS config, so tests can use throwaway self-signed certificates while
+// still exercising real version negotiation.
+func skipTlsVerifyForTest(t *testing.T) func() {
+	t.Helper()
+
+	original := newSendTlsConfig
+	newSendTlsConfig = func(host string, maxVersion uint16) *tls.Config {
+		config := original(host, maxVersion)
+		config.InsecureSkipVerify = true
+		return config
+	}
+
+	return func() { newSendTlsConfig = original }
+}

--- a/worker/tls_fallback_test.go
+++ b/worker/tls_fallback_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// selfSignedCert builds a throwaway certificate for the test TLS servers.
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	assert.NoError(t, err)
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// startTlsServer starts a TLS listener pinned to the given version range.
+func startTlsServer(t *testing.T, minVersion, maxVersion uint16) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	cert := selfSignedCert(t)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				tlsConn := tls.Server(conn, &tls.Config{
+					Certificates: []tls.Certificate{cert},
+					MinVersion:   minVersion,
+					MaxVersion:   maxVersion,
+				})
+				tlsConn.Handshake()
+				tlsConn.Close()
+			}()
+		}
+	}()
+
+	return listener
+}
+
+// handshakeAgainst dials addr and drives the lazy handshake to completion the
+// same way the worker does, by writing and then reading.
+func handshakeAgainst(t *testing.T, addr string, config *tls.Config) error {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", addr)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	tlsConn := tls.Client(conn, config)
+
+	if _, err := tlsConn.Write([]byte("EHLO test\r\n")); err != nil {
+		return err
+	}
+
+	buf := make([]byte, 1)
+	_, err = tlsConn.Read(buf)
+
+	return err
+}
+
+func TestIsTlsVersionNegotiationErrorOnRemoteAlert(t *testing.T) {
+
+	// server speaks only TLS 1.3, client is capped at 1.2, so the server
+	// rejects the ClientHello. This is the shape of the failure reported in
+	// the issue, and crypto/tls gives it no exported type.
+	server := startTlsServer(t, tls.VersionTLS13, tls.VersionTLS13)
+
+	err := handshakeAgainst(t, server.Addr().String(), &tls.Config{
+		ServerName:         "localhost",
+		InsecureSkipVerify: true,
+		MaxVersion:         tls.VersionTLS12,
+	})
+
+	assert.Error(t, err)
+	assert.True(t, isTlsVersionNegotiationError(err), "got %q", err)
+
+}
+
+func TestIsTlsVersionNegotiationErrorOnNonTlsPeer(t *testing.T) {
+
+	// a peer that answers with plaintext gives a tls.RecordHeaderError
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				conn.Write([]byte("500 not tls\r\n"))
+				conn.Close()
+			}()
+		}
+	}()
+
+	handshakeErr := handshakeAgainst(t, listener.Addr().String(), &tls.Config{
+		ServerName:         "localhost",
+		InsecureSkipVerify: true,
+	})
+
+	var recordErr tls.RecordHeaderError
+	assert.True(t, errors.As(handshakeErr, &recordErr))
+	assert.True(t, isTlsVersionNegotiationError(handshakeErr), "got %q", handshakeErr)
+
+}
+
+func TestIsTlsVersionNegotiationErrorIgnoresCertificateFailures(t *testing.T) {
+
+	// a certificate that does not verify is not something a lower TLS
+	// version can fix, so it must not trigger the fallback. Note its message
+	// also contains "tls: ", which is why the type check comes first.
+	server := startTlsServer(t, tls.VersionTLS12, tls.VersionTLS13)
+
+	err := handshakeAgainst(t, server.Addr().String(), &tls.Config{
+		ServerName: "localhost",
+	})
+
+	var certErr *tls.CertificateVerificationError
+	assert.True(t, errors.As(err, &certErr))
+	assert.Contains(t, err.Error(), "tls: ")
+	assert.False(t, isTlsVersionNegotiationError(err), "got %q", err)
+
+}
+
+func TestIsTlsVersionNegotiationErrorIgnoresUnrelatedErrors(t *testing.T) {
+
+	assert.False(t, isTlsVersionNegotiationError(nil))
+	assert.False(t, isTlsVersionNegotiationError(errors.New("connection reset by peer")))
+	assert.False(t, isTlsVersionNegotiationError(errors.New("EOF")))
+	assert.False(t, isTlsVersionNegotiationError(errors.New("i/o timeout")))
+
+}
+
+func TestTlsFallbackReachesAVersionIntolerantPeer(t *testing.T) {
+
+	// the fallback has to actually work: a server that will not speak above
+	// TLS 1.2 succeeds once the client caps itself there
+	server := startTlsServer(t, tls.VersionTLS12, tls.VersionTLS12)
+
+	err := handshakeAgainst(t, server.Addr().String(), &tls.Config{
+		ServerName:         "localhost",
+		InsecureSkipVerify: true,
+		MaxVersion:         tlsFallbackMaxVersion,
+	})
+
+	// the server closes right after the handshake, so EOF means the
+	// handshake itself succeeded
+	assert.False(t, isTlsVersionNegotiationError(err), "got %v", err)
+
+}


### PR DESCRIPTION
Closes #466

@JosefBrennecke this should cover the case you reported.

## Problem

`send.go` called `c.StartTLS(&tls.Config{ServerName: host})` with no version bounds. A receiving server that aborts the handshake on a TLS 1.3 `ClientHello` therefore killed the conversation, and because the failure surfaced as a network error the host was abandoned and the next MX tried, never the same host at a lower version.

## Change

When the handshake fails for a reason a version cap could fix, dial the host again with `MaxVersion` pinned to TLS 1.2 and retry once. Steps from the failed attempt are prepended to the retry conversation, so the SMTP log shows that 1.3 was tried first rather than presenting a bare TLS 1.2 delivery.

## Three things that are easy to get wrong here

**1. The handshake is lazy.** `tls.Client()` returns immediately, so a rejected `ClientHello` surfaces as an error from the **EHLO that follows STARTTLS**, not from `StartTLS()` itself. The conversation now records where the failure came from instead of leaving the caller to guess.

**2. The connection cannot be reused.** STARTTLS has already been issued on the failed socket, so the retry has to dial again.

**3. The error shapes are not uniform.** I checked these against `crypto/tls` rather than assuming, and the obvious implementation is wrong:

| Case | What Go returns | Matchable with `errors.As`? |
| --- | --- | --- |
| Peer rejects our ClientHello | `*tls.permanentError`, `"remote error: tls: protocol version not supported"` | **No**, the type is unexported |
| Peer is not speaking TLS | `tls.RecordHeaderError` | Yes |
| Certificate does not verify | `*tls.CertificateVerificationError` | Yes |

So the reported symptom has to be detected by message, and `*tls.CertificateVerificationError` has to be excluded **before** that check, because its message also contains `"tls: "`. Certificate failures deliberately do not trigger the fallback: a lower version cannot fix an untrusted certificate, and retrying would double the connections to every misconfigured host.

## Testing

Full suite green against a real Postgres.

The tests drive **real handshakes** rather than constructing error values by hand, so they fail if a future Go release changes these shapes. The integration test's SMTP server refuses the ClientHello via `GetConfigForClient` rather than negotiating down, which is what makes the failure unrecoverable on that connection and is the behaviour being reproduced.

It asserts the message gets through, that exactly **two** connections were made, and that the negotiated version was 1.2. A companion test asserts a healthy server still costs exactly **one** connection. Reverting the retry makes the first test fail.

## Note on scope

I left the existing certificate verification behaviour alone. Worth flagging separately that outgoing STARTTLS verifies certificates with no `InsecureSkipVerify`, which is stricter than typical opportunistic TLS, but that is a different discussion and not something I wanted to change under a bug fix.