### PR TITLE
health: show the expected PTR hostname when the check fails

### DIFF
--- a/backend/src/Service/Management/Health/AllActiveIpsHaveCorrectPtrHealthCheck.php
+++ b/backend/src/Service/Management/Health/AllActiveIpsHaveCorrectPtrHealthCheck.php
@@ -3,7 +3,9 @@
 namespace App\Service\Management\Health;
 
 use App\Entity\IpAddress;
+use App\Service\App\Config;
 use App\Service\Ip\IpAddressService;
+use App\Service\Ip\Ptr;
 use Doctrine\ORM\EntityManagerInterface;
 
 class AllActiveIpsHaveCorrectPtrHealthCheck extends HealthCheckAbstract
@@ -12,6 +14,7 @@ class AllActiveIpsHaveCorrectPtrHealthCheck extends HealthCheckAbstract
     public function __construct(
         private EntityManagerInterface $em,
         private IpAddressService $ipAddressService,
+        private Config $config,
     ) {
     }
 
@@ -32,6 +35,10 @@ class AllActiveIpsHaveCorrectPtrHealthCheck extends HealthCheckAbstract
             if (!$validation['forward']->valid || !$validation['reverse']->valid) {
                 $invalidData[] = [
                     'ip' => $ip->getIpAddress(),
+                    // the hostname both lookups are checked against. Without
+                    // it the console can only report that the PTR is wrong,
+                    // not what it should have been.
+                    'expected_ptr' => Ptr::getPtrDomain($ip, $this->config->getInstanceDomain()),
                     'forward_valid' => $validation['forward']->valid,
                     'forward_error' => $validation['forward']->error,
                     'reverse_valid' => $validation['reverse']->valid,

--- a/backend/tests/Service/Management/Health/AllActiveIpsHaveCorrectPtrHealthCheckTest.php
+++ b/backend/tests/Service/Management/Health/AllActiveIpsHaveCorrectPtrHealthCheckTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Service\Management\Health;
 
 use App\Entity\IpAddress;
+use App\Service\App\Config;
 use App\Service\Ip\Dto\PtrValidationDto;
 use App\Service\Ip\Ptr;
 use App\Service\Management\Health\AllActiveIpsHaveCorrectPtrHealthCheck;
@@ -31,7 +32,8 @@ class AllActiveIpsHaveCorrectPtrHealthCheckTest extends KernelTestCase
 
         $this->healthCheck = new AllActiveIpsHaveCorrectPtrHealthCheck(
             $this->em,
-            $ipAddressService
+            $ipAddressService,
+            $this->getService(Config::class)
         );
     }
 
@@ -102,5 +104,42 @@ class AllActiveIpsHaveCorrectPtrHealthCheckTest extends KernelTestCase
         $this->assertEquals('Simulated forward PTR failure', $invalidPtrs[0]['forward_error']);
         $this->assertFalse($invalidPtrs[0]['reverse_valid']);
         $this->assertEquals('Simulated reverse PTR failure', $invalidPtrs[0]['reverse_error']);
+    }
+
+    /**
+     * The reported problem was that the console could say the PTR was wrong
+     * but not what it should have been, so the operator had no way to know
+     * which hostname to point the record at.
+     */
+    public function testFailureDataIncludesTheExpectedPtrHostname(): void
+    {
+        $ip = IpAddressFactory::createOne([
+            'queue' => QueueFactory::new(),
+            'is_ptr_forward_valid' => true,
+            'is_ptr_reverse_valid' => false,
+        ]);
+
+        $this->ptr->method('validate')
+            ->willReturn([
+                'forward' => new PtrValidationDto(true),
+                'reverse' => new PtrValidationDto(false, 'DNS error: Non-existent domain (NXDOMAIN)'),
+            ]);
+
+        $this->assertFalse($this->healthCheck->check());
+
+        $invalidPtrs = $this->healthCheck->getData()['invalid_ptrs'];
+        $this->assertIsArray($invalidPtrs);
+        $this->assertIsArray($invalidPtrs[0]);
+
+        $expected = Ptr::getPtrDomain(
+            $ip->_real(),
+            $this->getService(Config::class)->getInstanceDomain()
+        );
+
+        $this->assertSame($expected, $invalidPtrs[0]['expected_ptr']);
+
+        // the whole point is that it names a specific host, not the bare
+        // instance domain
+        $this->assertStringStartsWith('smtp', $expected);
     }
 } 

--- a/frontend/src/routes/sudo/health/HealthCheckItem.svelte
+++ b/frontend/src/routes/sudo/health/HealthCheckItem.svelte
@@ -19,6 +19,16 @@
 		return dayjs(checkedAt).fromNow();
 	}
 
+	// the failure callout is rendered with {@html}, and some of these values
+	// come from remote DNS servers, so anything interpolated must be escaped
+	function escapeHtml(value: string): string {
+		return value
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;');
+	}
+
 	function renderFailureData(data: HealthCheckData[Key]): string {
 		if (checkKey === 'all_active_ips_have_correct_ptr') {
 			const ptrData = data as HealthCheckData['all_active_ips_have_correct_ptr'];
@@ -27,16 +37,27 @@
 				if (valid) {
 					return 'OK';
 				} else {
-					return 'invalid' + (error ? ` (${error})` : '');
+					return 'invalid' + (error ? ` (${escapeHtml(error)})` : '');
 				}
 			}
 
-			return `Invalid PTRs: ${ptrData.invalid_ptrs
-				.map(
-					(ptr) =>
-						`${ptr.ip}: forward ${getValidInvalidMsg(ptr.forward_valid, ptr.forward_error)}, reverse ${getValidInvalidMsg(ptr.reverse_valid, ptr.reverse_error)}`
-				)
-				.join(', ')}`;
+			function renderPtr(ptr: (typeof ptrData.invalid_ptrs)[number]): string {
+				const result =
+					`${escapeHtml(ptr.ip)}: ` +
+					`forward ${getValidInvalidMsg(ptr.forward_valid, ptr.forward_error)}, ` +
+					`reverse ${getValidInvalidMsg(ptr.reverse_valid, ptr.reverse_error)}`;
+
+				// health results are cached on the instance, so a run from
+				// before this field existed can still be on screen
+				if (!ptr.expected_ptr) {
+					return result;
+				}
+
+				return `${result}. Expected to see <code>${escapeHtml(ptr.expected_ptr)}</code>`;
+			}
+
+			// one IP per line: each entry already contains commas
+			return `Invalid PTRs:<br />${ptrData.invalid_ptrs.map(renderPtr).join('<br />')}`;
 		}
 
 		if (checkKey === 'all_queues_have_at_least_one_ip') {

--- a/frontend/src/routes/sudo/sudoTypes.ts
+++ b/frontend/src/routes/sudo/sudoTypes.ts
@@ -71,6 +71,8 @@ export interface HealthCheckData {
 	all_active_ips_have_correct_ptr: {
 		invalid_ptrs: Array<{
 			ip: string;
+			/** the hostname the PTR record should resolve to, e.g. smtp1.mail.example.net */
+			expected_ptr: string;
 			forward_valid: boolean;
 			forward_error: string | null;
 			reverse_valid: boolean;


### PR DESCRIPTION
Closes #458

Implements the message change @supun-io kept the issue open for.

## Problem

The check could say a PTR was wrong but not what it should have been:

```
Invalid PTRs: x.x.x.x: forward OK, reverse invalid (DNS error: Non-existent domain (NXDOMAIN))
```

The information was already there. `Ptr::getPtrDomain()` builds `smtp<id>.<instance_domain>` and both lookups are compared against it; it just never left the service.

## Change

`expected_ptr` is carried through on each failing IP and rendered, giving exactly the message asked for in the issue:

```
Invalid PTRs:
x.x.x.x: forward OK, reverse invalid (DNS error: Non-existent domain (NXDOMAIN)). Expected to see smtp1.mail.example.net
```

## Two other things in the same renderer

Both are in code I had to touch anyway; happy to split them out if you would rather review them separately.

- **Entries are one per line.** They were comma-joined, but each entry already contains commas, so several failing IPs ran together unreadably.
- **Interpolated values are now HTML-escaped.** This callout renders with `{@html}`, and `reverse_error` embeds answers from **remote DNS servers**, so that content was reaching the DOM unescaped.

## Compatibility

`expected_ptr` is treated as optional on the frontend. Health check results are cached on the `instances` row, so immediately after an upgrade the console still displays the previous run's payload, which predates the field. Without the guard that would render "Expected to see undefined" until the next run.

## Testing

Full PHP suite green against a real Postgres, matching `main`'s baseline. `npm run check` clean.

The new test reproduces the case from the issue (reverse lookup returning NXDOMAIN) and asserts the payload names the specific host rather than the bare instance domain.