### PR TITLE
grafana: filter Total HTTP Requests by the selected time range

### DIFF
--- a/meta/monitoring/grafana.json
+++ b/meta/monitoring/grafana.json
@@ -2192,7 +2192,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(http_requests_total{job=\"$job\", instance=~\"$instance\"})",
+          "expr": "round(sum(increase(http_requests_total{job=\"$job\", instance=~\"$instance\"}[$__range])))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/meta/monitoring/grafana.json
+++ b/meta/monitoring/grafana.json
@@ -2410,7 +2410,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sort_desc(sum(max_over_time(http_requests_total{job=\"$job\",instance=~\"$instance\"}[$__range])- min_over_time(http_requests_total{job=\"$job\",instance=~\"$instance\"}[$__range])) by (status))",
+          "expr": "sort_desc(floor(sum by(status) (increase(http_requests_total{job=\"$job\",instance=~\"$instance\"}[$__range]))))",
           "format": "table",
           "instant": true,
           "interval": "",


### PR DESCRIPTION
Closes #282

## The reported bug

The "Total HTTP Requests" stat panel queried the raw counter:

```promql
sum(http_requests_total{job="$job", instance=~"$instance"})
```

That is the number of requests since each process started, so the panel ignored the time picker entirely and the number only ever grew. Every other "Total" stat on this dashboard already does the right thing (Total Send Attempts, Total Sent Webhooks, Total DNS Queries, Total Incoming Mails), so this is now consistent with them:

```promql
round(sum(increase(http_requests_total{job="$job", instance=~"$instance"}[$__range])))
```

## Second commit, same row

"Requests by Status" computes its delta by hand:

```promql
max_over_time(counter[$__range]) - min_over_time(counter[$__range])
```

which undercounts whenever the counter resets inside the window. That is not a rare event here, since the servers are restarted whenever their config changes, and each restart puts the max before the reset and the min after it. Switched to `increase()`, matching "Requests by Endpoint" right next to it.

It is a separate commit because it is a different panel, so feel free to drop it if you would rather keep this PR to the reported bug.

## Unrelated thing I noticed, not fixed here

The header text panel renders the environment twice:

```
env: ${info_env}
version: ${info_env}
```

There is no `info_version` template variable defined, though `relay_info` does carry a `version` label. Fixing it means adding a variable, which felt out of scope for this issue. Happy to open a separate PR if useful.

## Testing

JSON validates and the dashboard structure is unchanged apart from the two `expr` strings.